### PR TITLE
#1803|#1835 Fixed klarna getTitle on failed purchase atempt

### DIFF
--- a/src/Model/Payment/Kp.php
+++ b/src/Model/Payment/Kp.php
@@ -15,13 +15,29 @@ use Magento\Payment\Model\Method\Adapter;
 use Magento\Framework\Locale\Resolver;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Quote\Api\Data\CartInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use \Magento\Framework\Exception\NoSuchEntityException;
 
 class Kp extends KpSource
 {
+    private const DEFAULT_TITLE = 'Klarna Payments';
+    private const KLARNA_TITLE_PATH = 'payment/klarna_kp/title';
+
     /**
      * @var Adapter
      */
     private $adapter;
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $config;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
     /**
      * @param Adapter $adapter
      * @param Resolver $resolver
@@ -32,10 +48,13 @@ class Kp extends KpSource
         Adapter $adapter,
         Resolver $resolver,
         ScopeConfigInterface $config,
-        SessionInitiatorFactory $sessionInitiatorFactory
+        SessionInitiatorFactory $sessionInitiatorFactory,
+        StoreManagerInterface $storeManager
     ) {
         parent::__construct($adapter, $resolver, $config, $sessionInitiatorFactory);
         $this->adapter = $adapter;
+        $this->config = $config;
+        $this->storeManager = $storeManager;
     }
 
     /**
@@ -44,5 +63,23 @@ class Kp extends KpSource
     public function isAvailable(?CartInterface $quote = null)
     {
         return !!$this->adapter->isAvailable($quote);
+    }
+
+    /**
+     * Fixes issue with klarna un-linking after
+     * failed purchase atempt, by catcginh title from
+     * config directly
+     */
+    public function getTitle()
+    {
+        try {
+            return parent::getTitle();
+        } catch (NoSuchEntityException $exception) {
+            return $this->config->getValue(
+                self::KLARNA_TITLE_PATH,
+                'store',
+                $this->storeManager->getStore()->getId()
+            ) ?? __(self::DEFAULT_TITLE);
+        }
     }
 }


### PR DESCRIPTION
Original issues: 
- [#1803](https://github.com/scandipwa/scandipwa/issues/1803) 
- [#1835](https://github.com/scandipwa/scandipwa/issues/1835)

In this PR:
- After failed purchase attempt Klarnas `getTitle` method gets un-linked & returns error message on payment page... to fix that added direct config loading on failed attempt.